### PR TITLE
fix: change trigger action to push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  pull_request:
+  push:
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION
Change pull_request to push, as a pull_request will not trigger a new semantic version number.